### PR TITLE
Added option to group only within libraries.

### DIFF
--- a/AutoCollections.Tasks/CollectionsScheduleTask.cs
+++ b/AutoCollections.Tasks/CollectionsScheduleTask.cs
@@ -1,4 +1,4 @@
-using MediaBrowser.Controller.Entities;
+﻿using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Tasks;
 using System;
@@ -57,7 +57,7 @@ namespace AutoCollections.AutoCollections.Tasks
                 }
                 var queryList = new InternalItemsQuery
                 {
-                    Recursive = false,
+                    Recursive = true,
                     ParentIds = new[] { fldr.InternalId },
                     IncludeItemTypes = new[] { "Movie" },
                     IsVirtualItem = false,

--- a/AutoCollections.Tasks/CollectionsScheduleTask.cs
+++ b/AutoCollections.Tasks/CollectionsScheduleTask.cs
@@ -37,7 +37,8 @@ namespace AutoCollections.AutoCollections.Tasks
         {
             _itemsList.Clear();
             PluginConfiguration config = Plugin.Instance.Configuration;
-            Log.Info("Getting items to process", null);
+            Log.Info("Running movie version grouping... (DoNotChangeLockedItems: {0}, MergeAcrossLibraries: {1})", 
+                config.DoNotChangeLockedItems, config.MergeAcrossLibraries);
             var stopWatch = new Stopwatch();
             stopWatch.Start();
             InternalItemsQuery libraries = new InternalItemsQuery
@@ -46,10 +47,12 @@ namespace AutoCollections.AutoCollections.Tasks
                 Recursive = false,
             };
             var libraryFolders = _libraryManager.GetItemList(libraries).ToList();
+            Log.Info("Found {0} libraries. Scanning movies...", libraryFolders.Count());
             foreach (var fldr in libraryFolders)
             {
                 if (fldr.Name == "Top Picks")
                 {
+                    Log.Info("Ignoring library \"Top Picks\".");
                     continue;
                 }
                 var queryList = new InternalItemsQuery
@@ -61,19 +64,26 @@ namespace AutoCollections.AutoCollections.Tasks
                 };
 
                 var libraryItemsList = _libraryManager.GetItemList(queryList).ToList();
+                Log.Info("Found {0} movie files in library \"{1}\".", libraryItemsList.Count(), fldr.Name);
+
                 foreach (var item in libraryItemsList)
                 {
                     if (config.DoNotChangeLockedItems && item.IsLocked)
                     {
-                        Log.Info("Locked Item: {0}", item.Name);
+                        Log.Info("Ignoring locked item: {0}", item.Name);
                         continue;
                     }
+                    /* Log.Debug("Including item {0}. alt. count: {1} tmdb: {2} imdb: {3} ", item.Path,
+                     * ((Video) item).GetAlternateVersionIds().Count,
+                     * item.GetProviderId(MetadataProviders.Tmdb), item.GetProviderId(MetadataProviders.Imdb));
+                     */
                     _itemsList.Add(Tuple.Create(config.MergeAcrossLibraries ? "" : fldr.InternalId.ToString(), item));
                 }
             }
+            Log.Info("Found a total of {0} movie files.", _itemsList.Count());
 
             stopWatch.Stop();
-            Log.Info("GetItemsToProcess took {0} ms", stopWatch.ElapsedMilliseconds.ToString());
+            Log.Debug("Library scan took {0} ms", stopWatch.ElapsedMilliseconds.ToString());
         }
 
         public async Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
@@ -88,49 +98,36 @@ namespace AutoCollections.AutoCollections.Tasks
                 }
                 ScanTaskRunning = true;
             }
-            Log.Info("Executing Automatic Collections creation.  Searching distinct movies with separated versions," + 
-                " DoNotChangeLockedMovies = '{0}', MergeAcrossLibraries = '{1}'", config.DoNotChangeLockedItems, config.MergeAcrossLibraries);
 
             IEnumerable<Tuple<string, BaseItem>> items = from i in _itemsList
                                             where i.Item2.LocationType == 0 && i.Item2.MediaType == "Video" && i.Item2.Path != null 
                                                 && !i.Item2.IsVirtualItem && i.Item2.GetTopParent() != null && !(i.Item2.Parent.GetParent() is BoxSet)
                                             select i;
-            int num = items.Count();
-            int num2 = (from i in items
-                        where i.Item2.ProviderIds != null && i.Item2.GetProviderId(MetadataProviders.Tmdb) != null
-                        group i by i.Item1 + i.Item2.GetProviderId(MetadataProviders.Tmdb) into i
-                        where i.Count() > 1
-                        select i).ToList().Count + (from i in items
-                                                    where i.Item2.ProviderIds != null && i.Item2.GetProviderId(MetadataProviders.Imdb) != null 
-                                                        && i.Item2.GetProviderId(MetadataProviders.Tmdb) == null
-                                                    group i by i.Item1 + i.Item2.GetProviderId(MetadataProviders.Imdb) into i
-                                                    where i.Count() > 1
-                                                    select i).ToList().Count;
-            Log.Info("Found {0} of {1} movies that have multiple versions ...", num2, num);
-            Log.Info("Searching distinct tmdb movies ...", null);
+
+            Log.Info("Identifying ungrouped movies with a common tmdb id...", null);
             List<IGrouping<string, BaseItem>> list = (from i in items
                                                       where i.Item2.ProviderIds != null && i.Item2.GetProviderId(MetadataProviders.Tmdb) != null
                                                       group i.Item2 by i.Item1 + i.Item2.GetProviderId(MetadataProviders.Tmdb).ToString() into j
                                                       where j.Count() != 1 + j.OfType<Video>().Sum(video => video.GetAlternateVersionIds().Count) / j.Count()
                                                       select j).ToList();
-            Log.Info("Searching distinct imdb movies ...", null);
+            Log.Info("Identifying ungrouped movies with a common imdb id...", null);
             List<IGrouping<string, BaseItem>> list2 = (from i in items
                                                         where i.Item2.ProviderIds != null && i.Item2.GetProviderId(MetadataProviders.Tmdb) == null 
                                                             && i.Item2.GetProviderId(MetadataProviders.Imdb) != null
                                                         group i.Item2 by i.Item1 + i.Item2.GetProviderId(MetadataProviders.Imdb) into j
                                                         where j.Count() != 1 + j.OfType<Video>().Sum(video => video.GetAlternateVersionIds().Count) / j.Count()
                                                         select j).ToList();
-            Log.Info("Found {0} tmdb and {1} imdb version movie lists, merging them to process ...", list.Count, list2.Count);
+            Log.Info("Found {0} ungrouped movies with a common tmdb id and {1} with a common imdb id. Merging ungrouped versions...", list.Count, list2.Count);
             list.AddRange(list2);
 
             int actionrequiredmoviecount = list.Count;
             if (actionrequiredmoviecount == 0)
             {
-                Log.Info("No movies with multiple ungrouped versions found, we're done!", null);
+                Log.Info("Found no movies with ungrouped versions, we're done!");
             }
             else
             {
-                Log.Info("Executing Movie version grouping. Found {0} movies require regrouping and update.", actionrequiredmoviecount);
+                Log.Info("Found {0} movies that require regrouping.", actionrequiredmoviecount);
                 double current = 1.0;
                 List<IGrouping<string, BaseItem>>.Enumerator enumerator = list.GetEnumerator();
                 try
@@ -162,7 +159,7 @@ namespace AutoCollections.AutoCollections.Tasks
         {
             Plugin plugin = Plugin.Instance;
             int num = collection.Count();
-            Log.Debug("Found movie {0} ({1}) with {2} separate versions - (re)grouping them.", collection.Key, collection.First().Name, num);
+            Log.Debug("Updating movie {0} ({1}) with {2} separate versions.", collection.Key, collection.First().Name, num);
 
             bool result = false;
             if (num > 1)
@@ -171,7 +168,7 @@ namespace AutoCollections.AutoCollections.Tasks
             }
             else
             {
-                Log.Debug("single item version - resetting linked items.", null);
+                Log.Debug("Single version movie. Splitting versions.", null);
                 BaseItem[] array = collection.ToArray();
                 foreach (BaseItem val in array)
                 {

--- a/AutoCollections.Tasks/CollectionsScheduleTask.cs
+++ b/AutoCollections.Tasks/CollectionsScheduleTask.cs
@@ -97,27 +97,27 @@ namespace AutoCollections.AutoCollections.Tasks
                                             select i;
             int num = items.Count();
             int num2 = (from i in items
-                        where i.Item2.ProviderIds != null && i.Item2.GetProviderId((MetadataProviders)3) != null
-                        group i by i.Item1 + i.Item2.GetProviderId((MetadataProviders)3) into i
+                        where i.Item2.ProviderIds != null && i.Item2.GetProviderId(MetadataProviders.Tmdb) != null
+                        group i by i.Item1 + i.Item2.GetProviderId(MetadataProviders.Tmdb) into i
                         where i.Count() > 1
                         select i).ToList().Count + (from i in items
-                                                    where i.Item2.ProviderIds != null && i.Item2.GetProviderId((MetadataProviders)2) != null 
-                                                        && i.Item2.GetProviderId((MetadataProviders)3) == null
-                                                    group i by i.Item1 + i.Item2.GetProviderId((MetadataProviders)2) into i
+                                                    where i.Item2.ProviderIds != null && i.Item2.GetProviderId(MetadataProviders.Imdb) != null 
+                                                        && i.Item2.GetProviderId(MetadataProviders.Tmdb) == null
+                                                    group i by i.Item1 + i.Item2.GetProviderId(MetadataProviders.Imdb) into i
                                                     where i.Count() > 1
                                                     select i).ToList().Count;
             Log.Info("Found {0} of {1} movies that have multiple versions ...", num2, num);
             Log.Info("Searching distinct tmdb movies ...", null);
             List<IGrouping<string, BaseItem>> list = (from i in items
-                                                      where i.Item2.ProviderIds != null && i.Item2.GetProviderId((MetadataProviders)3) != null
-                                                      group i.Item2 by i.Item1 + i.Item2.GetProviderId((MetadataProviders)3).ToString() into j
+                                                      where i.Item2.ProviderIds != null && i.Item2.GetProviderId(MetadataProviders.Tmdb) != null
+                                                      group i.Item2 by i.Item1 + i.Item2.GetProviderId(MetadataProviders.Tmdb).ToString() into j
                                                       where j.Count() != 1 + j.OfType<Video>().Sum(video => video.GetAlternateVersionIds().Count) / j.Count()
                                                       select j).ToList();
             Log.Info("Searching distinct imdb movies ...", null);
             List<IGrouping<string, BaseItem>> list2 = (from i in items
-                                                        where i.Item2.ProviderIds != null && i.Item2.GetProviderId((MetadataProviders)3) == null 
-                                                            && i.Item2.GetProviderId((MetadataProviders)2) != null
-                                                        group i.Item2 by i.Item1 + i.Item2.GetProviderId((MetadataProviders)2) into j
+                                                        where i.Item2.ProviderIds != null && i.Item2.GetProviderId(MetadataProviders.Tmdb) == null 
+                                                            && i.Item2.GetProviderId(MetadataProviders.Imdb) != null
+                                                        group i.Item2 by i.Item1 + i.Item2.GetProviderId(MetadataProviders.Imdb) into j
                                                         where j.Count() != 1 + j.OfType<Video>().Sum(video => video.GetAlternateVersionIds().Count) / j.Count()
                                                         select j).ToList();
             Log.Info("Found {0} tmdb and {1} imdb version movie lists, merging them to process ...", list.Count, list2.Count);

--- a/AutoCollections.Tasks/CollectionsScheduleTask.cs
+++ b/AutoCollections.Tasks/CollectionsScheduleTask.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Tasks;
 using System;
@@ -35,6 +35,7 @@ namespace AutoCollections.AutoCollections.Tasks
 
         private async Task GetItemsToProcess()
         {
+            _itemsList.Clear();
             PluginConfiguration config = Plugin.Instance.Configuration;
             Log.Info("Getting items to process", null);
             var stopWatch = new Stopwatch();

--- a/Config/AGConfigPage.html
+++ b/Config/AGConfigPage.html
@@ -13,6 +13,11 @@
 						<span class="toggleButtonLabel mdl-switch__label">Ignore if Movie is Locked</span>
 					</label>
 					<div class="fieldDescription">Do not proceed with grouping if the Movie is Locked in the Metadata Editor</div>
+                    <label>
+						<input is="emby-toggle" type="checkbox" class="chkMergeAcrossLibraries" />
+						<span class="toggleButtonLabel mdl-switch__label">Merge items across different libraries</span>
+					</label>
+					<div class="fieldDescription">Group movies across all libraries. This will allow to select all available versions in any library.</div>
 				</div>
 
 				<h3>Auto Movie Version Grouping will keep movie groups updated, Please run the Scheduled Task or set up a Task Trigger.</h3>
@@ -29,3 +34,4 @@
 		</div>
 	</div>
 </div>
+

--- a/Config/AGConfigPage.js
+++ b/Config/AGConfigPage.js
@@ -18,10 +18,9 @@
 
                 loading.show();
 
-                var config = await ApiClient.getPluginConfiguration(pluginId);
-
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     view.querySelector('.chkDoNotChangeLockedItems').checked = config.DoNotChangeLockedItems || false;
+                    view.querySelector('.chkMergeAcrossLibraries').checked = config.MergeAcrossLibraries || false;
 
                 });
 
@@ -33,6 +32,18 @@
                         e.preventDefault();
                         ApiClient.getPluginConfiguration(pluginId).then((config) => {
                             config.DoNotChangeLockedItems = dontChange.checked;
+                            ApiClient.updatePluginConfiguration(pluginId, config).then((r) => {
+                                Dashboard.processPluginConfigurationUpdateResult(r);
+                            });
+                        });
+                    });
+
+                var crossLibrary = view.querySelector(".chkMergeAcrossLibraries");
+                crossLibrary.addEventListener('change',
+                    (e) => {
+                        e.preventDefault();
+                        ApiClient.getPluginConfiguration(pluginId).then((config) => {
+                            config.MergeAcrossLibraries = crossLibrary.checked;
                             ApiClient.updatePluginConfiguration(pluginId, config).then((r) => {
                                 Dashboard.processPluginConfigurationUpdateResult(r);
                             });

--- a/Config/PluginConfiguration.cs
+++ b/Config/PluginConfiguration.cs
@@ -10,9 +10,12 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool DoNotChangeLockedItems { get; set; }
 
+    public bool MergeAcrossLibraries { get; set; }
+
     public PluginConfiguration()
     {
         DoNotChangeLockedItems = false;
+        MergeAcrossLibraries = true;
         MinimumMembers = 2;
         NeedsUpdate = true;
     }

--- a/Configuration/AGConfigurationPage.html
+++ b/Configuration/AGConfigurationPage.html
@@ -13,10 +13,15 @@
 						<span class="toggleButtonLabel mdl-switch__label">Ignore if Movie is Locked</span>
 					</label>
 					<div class="fieldDescription">Do not proceed with grouping if the Movie is Locked in the Metadata Editor</div>
+                    <label>
+						<input is="emby-toggle" type="checkbox" class="chkMergeAcrossLibraries" />
+						<span class="toggleButtonLabel mdl-switch__label">Merge items across different libraries</span>
+					</label>
+					<div class="fieldDescription">Group movies across all libraries. This will allow to select all available versions in any library.</div>
 				</div>
-				
+
 				<h3>Auto Movie Version Grouping will keep movie groups updated, Please run the Scheduled Task or set up a Task Trigger.</h3>
-				<hr/>
+				<hr />
 				<p style="margin: 2em 0;">
 					You also can manually force a refresh with this button.
 				</p>
@@ -26,6 +31,7 @@
 				</div>
 
 			</div>
-			</div>
+		</div>
 	</div>
 </div>
+

--- a/Configuration/AGConfigurationPage.js
+++ b/Configuration/AGConfigurationPage.js
@@ -12,21 +12,20 @@
             });
             Dashboard.alert("Movie Version Collections Refresh Started");
         }
-        
+
         return function (view) {
             view.addEventListener('viewshow', async () => {
 
                 loading.show();
 
-                var config = await ApiClient.getPluginConfiguration(pluginId);
-                
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     view.querySelector('.chkDoNotChangeLockedItems').checked = config.DoNotChangeLockedItems || false;
-                    
+                    view.querySelector('.chkMergeAcrossLibraries').checked = config.MergeAcrossLibraries || false;
+
                 });
 
                 loading.hide();
-                
+
                 var dontChange = view.querySelector(".chkDoNotChangeLockedItems");
                 dontChange.addEventListener('change',
                     (e) => {
@@ -37,14 +36,26 @@
                                 Dashboard.processPluginConfigurationUpdateResult(r);
                             });
                         });
-                    });   
+                    });
+
+                var crossLibrary = view.querySelector(".chkMergeAcrossLibraries");
+                crossLibrary.addEventListener('change',
+                    (e) => {
+                        e.preventDefault();
+                        ApiClient.getPluginConfiguration(pluginId).then((config) => {
+                            config.MergeAcrossLibraries = crossLibrary.checked;
+                            ApiClient.updatePluginConfiguration(pluginId, config).then((r) => {
+                                Dashboard.processPluginConfigurationUpdateResult(r);
+                            });
+                        });
+                    });
 
                 var update = view.querySelector(".btnUpdate");
                 update.addEventListener('click', e => {
                     e.preventDefault();
                     refreshCollections();
                 });
-                
+
                 document.querySelector('.pageTitle').innerHTML = "Auto Version Grouping";
 
             });


### PR DESCRIPTION
I added an option to limit the grouping to items that belong to the same library. This can be configured in the settings and the default is still the old behaviour, so it shouldn't interfere. Switching between the two modes should work just fine with the changes being applied after manually running the grouping task.

I do not have any experience with emby plugins (or C#) and I couldn't find a way to access an item's library id from the item itself (item.getParent() returns the the parent directory instead of the library), so I went the extra step to change _itemsList to accept tuples that include the library id. There's probably a much better way to do this, but it works just fine.